### PR TITLE
feat: 도메인 구조 설계

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
     runtimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    
+    // Swagger UI (Springdoc OpenAPI)
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
 }
 
 spotless {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,9 @@ repositories {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     runtimeOnly("com.h2database:h2")
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/java/org/rhizome/server/config/SwaggerConfig.java
+++ b/src/main/java/org/rhizome/server/config/SwaggerConfig.java
@@ -1,0 +1,28 @@
+package org.rhizome.server.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+
+@OpenAPIDefinition(
+        info =
+                @io.swagger.v3.oas.annotations.info.Info(
+                        title = "Rhizome Project API",
+                        description = "Rhizome Project API 명세서",
+                        version = "v1.0.0"))
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Server server = new Server();
+        server.setUrl("/");
+
+        return new OpenAPI().servers(List.of(server));
+    }
+}

--- a/src/main/java/org/rhizome/server/domain/article/controller/ArticleController.java
+++ b/src/main/java/org/rhizome/server/domain/article/controller/ArticleController.java
@@ -1,0 +1,29 @@
+package org.rhizome.server.domain.article.controller;
+
+import org.rhizome.server.domain.article.service.ArticleServiceImpl;
+import org.rhizome.server.support.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+
+@RestController
+@RequestMapping("/api/articles")
+public class ArticleController {
+
+    private final ArticleServiceImpl articleServiceImpl;
+
+    public ArticleController(ArticleServiceImpl articleServiceImpl) {
+        this.articleServiceImpl = articleServiceImpl;
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "게시글 조회", description = "ID로 게시글을 조회합니다.")
+    public ResponseEntity<ApiResponse<?>> getArticle(@PathVariable Long id) {
+
+        return ResponseEntity.ok(ApiResponse.success(articleServiceImpl.getArticle(id)));
+    }
+}

--- a/src/main/java/org/rhizome/server/domain/article/controller/ArticleController.java
+++ b/src/main/java/org/rhizome/server/domain/article/controller/ArticleController.java
@@ -1,6 +1,6 @@
 package org.rhizome.server.domain.article.controller;
 
-import org.rhizome.server.domain.article.service.ArticleServiceImpl;
+import org.rhizome.server.domain.article.service.ArticleService;
 import org.rhizome.server.support.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,21 +9,19 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/articles")
 public class ArticleController {
 
-    private final ArticleServiceImpl articleServiceImpl;
-
-    public ArticleController(ArticleServiceImpl articleServiceImpl) {
-        this.articleServiceImpl = articleServiceImpl;
-    }
+    private final ArticleService articleService;
 
     @GetMapping("/{id}")
     @Operation(summary = "게시글 조회", description = "ID로 게시글을 조회합니다.")
     public ResponseEntity<ApiResponse<?>> getArticle(@PathVariable Long id) {
 
-        return ResponseEntity.ok(ApiResponse.success(articleServiceImpl.getArticle(id)));
+        return ResponseEntity.ok(ApiResponse.success(articleService.getArticle(id)));
     }
 }

--- a/src/main/java/org/rhizome/server/domain/article/domain/Article.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/Article.java
@@ -1,0 +1,47 @@
+package org.rhizome.server.domain.article.domain;
+
+import java.time.LocalDateTime;
+
+import org.rhizome.server.support.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Article extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private Article(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+    public Article createArticle(String title, String content) {
+        return Article.builder().title(title).content(content).build();
+    }
+}

--- a/src/main/java/org/rhizome/server/domain/article/domain/Article.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/Article.java
@@ -41,7 +41,7 @@ public class Article extends BaseTimeEntity {
         this.content = content;
     }
 
-    public static Article createArticle(String title, String content) {
+    public static Article create(String title, String content) {
         return Article.builder().title(title).content(content).build();
     }
 }

--- a/src/main/java/org/rhizome/server/domain/article/domain/Article.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/Article.java
@@ -41,7 +41,7 @@ public class Article extends BaseTimeEntity {
         this.content = content;
     }
 
-    public Article createArticle(String title, String content) {
+    public static Article createArticle(String title, String content) {
         return Article.builder().title(title).content(content).build();
     }
 }

--- a/src/main/java/org/rhizome/server/domain/article/domain/ArticleReference.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/ArticleReference.java
@@ -37,7 +37,7 @@ public class ArticleReference extends BaseTimeEntity {
         this.targetArticle = targetArticle;
     }
 
-    public ArticleReference createArticleReference(Article sourceArticle, Article targetArticle) {
+    public static ArticleReference createArticleReference(Article sourceArticle, Article targetArticle) {
         return ArticleReference.builder()
                 .sourceArticle(sourceArticle)
                 .targetArticle(targetArticle)

--- a/src/main/java/org/rhizome/server/domain/article/domain/ArticleReference.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/ArticleReference.java
@@ -37,7 +37,7 @@ public class ArticleReference extends BaseTimeEntity {
         this.targetArticle = targetArticle;
     }
 
-    public static ArticleReference createArticleReference(Article sourceArticle, Article targetArticle) {
+    public static ArticleReference create(Article sourceArticle, Article targetArticle) {
         return ArticleReference.builder()
                 .sourceArticle(sourceArticle)
                 .targetArticle(targetArticle)

--- a/src/main/java/org/rhizome/server/domain/article/domain/ArticleReference.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/ArticleReference.java
@@ -1,0 +1,46 @@
+package org.rhizome.server.domain.article.domain;
+
+import org.rhizome.server.support.BaseTimeEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleReference extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_post_id", nullable = false)
+    private Article sourceArticle;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_post_id", nullable = false)
+    private Article targetArticle;
+
+    @Builder
+    private ArticleReference(Article sourceArticle, Article targetArticle) {
+        this.sourceArticle = sourceArticle;
+        this.targetArticle = targetArticle;
+    }
+
+    public ArticleReference createArticleReference(Article sourceArticle, Article targetArticle) {
+        return ArticleReference.builder()
+                .sourceArticle(sourceArticle)
+                .targetArticle(targetArticle)
+                .build();
+    }
+}

--- a/src/main/java/org/rhizome/server/domain/article/domain/ArticleRepository.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/ArticleRepository.java
@@ -1,11 +1,9 @@
 package org.rhizome.server.domain.article.domain;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ArticleRepository extends JpaRepository<Article, Long> {
-    Optional<Article> findById(Long id);
+
 }

--- a/src/main/java/org/rhizome/server/domain/article/domain/ArticleRepository.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/ArticleRepository.java
@@ -1,0 +1,11 @@
+package org.rhizome.server.domain.article.domain;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+    Optional<Article> findById(Long id);
+}

--- a/src/main/java/org/rhizome/server/domain/article/dto/ArticleResponseDto.java
+++ b/src/main/java/org/rhizome/server/domain/article/dto/ArticleResponseDto.java
@@ -1,0 +1,37 @@
+package org.rhizome.server.domain.article.dto;
+
+import java.time.LocalDateTime;
+
+import org.rhizome.server.domain.article.domain.Article;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ArticleResponseDto {
+    private Long id;
+    private String title;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private ArticleResponseDto(
+            Long id, String title, String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.title = title;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public static ArticleResponseDto of(Article article) {
+        return ArticleResponseDto.builder()
+                .id(article.getId())
+                .title(article.getTitle())
+                .content(article.getContent())
+                .createdAt(article.getCreatedAt())
+                .updatedAt(article.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/org/rhizome/server/domain/article/service/ArticleService.java
+++ b/src/main/java/org/rhizome/server/domain/article/service/ArticleService.java
@@ -1,0 +1,7 @@
+package org.rhizome.server.domain.article.service;
+
+import org.rhizome.server.domain.article.dto.ArticleResponseDto;
+
+public interface ArticleService {
+    public ArticleResponseDto getArticle(Long id);
+}

--- a/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
+++ b/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
@@ -1,0 +1,25 @@
+package org.rhizome.server.domain.article.service;
+
+import static org.rhizome.server.support.error.ErrorType.*;
+
+import org.rhizome.server.domain.article.domain.Article;
+import org.rhizome.server.domain.article.domain.ArticleRepository;
+import org.rhizome.server.domain.article.dto.ArticleResponseDto;
+import org.rhizome.server.support.error.CoreException;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleServiceImpl implements ArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    @Override
+    public ArticleResponseDto getArticle(Long id) {
+        Article article = articleRepository.findById(id).orElseThrow(() -> new CoreException(INVALID_ARTICLE));
+
+        return ArticleResponseDto.of(article);
+    }
+}

--- a/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
+++ b/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
@@ -18,7 +18,7 @@ public class ArticleServiceImpl implements ArticleService {
 
     @Override
     public ArticleResponseDto getArticle(Long id) {
-        Article article = articleRepository.findById(id).orElseThrow(() -> new CoreException(INVALID_ARTICLE));
+        Article article = articleRepository.findById(id).orElseThrow(() -> new CoreException(ARTICLE_NOT_FOUND));
 
         return ArticleResponseDto.of(article);
     }

--- a/src/main/java/org/rhizome/server/support/BaseTimeEntity.java
+++ b/src/main/java/org/rhizome/server/support/BaseTimeEntity.java
@@ -1,0 +1,34 @@
+package org.rhizome.server.support;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column
+    private LocalDateTime updatedAt;
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt.atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt.atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime();
+    }
+}

--- a/src/main/java/org/rhizome/server/support/error/ErrorCode.java
+++ b/src/main/java/org/rhizome/server/support/error/ErrorCode.java
@@ -1,5 +1,5 @@
 package org.rhizome.server.support.error;
 
 public enum ErrorCode {
-    E500
+    E500, E400
 }

--- a/src/main/java/org/rhizome/server/support/error/ErrorType.java
+++ b/src/main/java/org/rhizome/server/support/error/ErrorType.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorType {
     DEFAULT_ERROR(
-            HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.", LogLevel.ERROR);
+            HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.", LogLevel.ERROR),
+    INVALID_ARTICLE(HttpStatus.BAD_REQUEST, ErrorCode.E500, "존재하지 않는 게시글입니다.", LogLevel.WARN);
 
     private final HttpStatus status;
 

--- a/src/main/java/org/rhizome/server/support/error/ErrorType.java
+++ b/src/main/java/org/rhizome/server/support/error/ErrorType.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
     DEFAULT_ERROR(
             HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.", LogLevel.ERROR),
-    INVALID_ARTICLE(HttpStatus.BAD_REQUEST, ErrorCode.E500, "존재하지 않는 게시글입니다.", LogLevel.WARN);
+    ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E400, "존재하지 않는 게시글입니다.", LogLevel.WARN);
 
     private final HttpStatus status;
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,6 +9,20 @@ spring:
     properties:
       hibernate.default_batch_fetch_size: 100
 
+# Swagger(OpenAPI) 설정
+springdoc:
+  version: 1.0.0
+  api-docs:
+    path: /api-docs
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    path: /swagger-ui.html
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+    tags-sorter: alpha
+
 ---
 spring.config.activate.on-profile: local
 


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
closed #3 

게시글 도메인 구성, Swagger 기반의 API 문서화

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->:

Swagger 설정:
	•	SwaggerConfig 클래스를 추가하여 OpenAPI 기반의 서버 URL 및 API 문서의 제목, 설명, 버전 등의 메타데이터를 설정했습니다. )
	•	Swagger UI 커스터마이징 및 문서 생성을 위한 설정을 application.yaml에 추가했습니다. 

게시글 관리 API:
	•	ArticleController 클래스에 게시글 ID로 조회할 수 있는 GET API 엔드포인트를 구현했으며, Swagger 어노테이션을 활용해 문서화했습니다.
	•	게시글 조회 비즈니스 로직을 처리하기 위한 ArticleService 인터페이스와 구현체인 ArticleServiceImpl을 추가했습니다. 
	•	API 응답 구조를 위한 ArticleResponseDto 클래스를 생성했습니다. 

지원 인프라 구성:
	•	게시글 및 게시글 간 참조 관계를 표현하기 위해 Article과 ArticleReference 엔티티를 생성하고, JPA 어노테이션을 활용해 영속성을 구성했습니다. 
	•	게시글 관련 DB 작업을 위한 JPA 리포지토리 ArticleRepository를 추가했습니다.
	•	생성 및 수정 시각 자동 기록을 위한 BaseTimeEntity 클래스를 도입했습니다. 
	•	게시글 관련 유효성 검사 실패 시 활용될 새로운 에러 타입을 ErrorType enum에 추가했습니다. 
