### PR TITLE
Fix(#10): 트랜잭션을 통해 세션 닫히는 문제 해결

### DIFF
--- a/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
+++ b/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
@@ -85,6 +85,7 @@ public class ArticleServiceImpl implements ArticleService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public AllArticleResponse getArticles() {
         List<Article> articles = articleRepository.findAll();
 

--- a/src/test/java/org/rhizome/server/IntegrationTestSupport.java
+++ b/src/test/java/org/rhizome/server/IntegrationTestSupport.java
@@ -1,0 +1,10 @@
+package org.rhizome.server;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+
+@ActiveProfiles("local")
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@SpringBootTest
+public abstract class IntegrationTestSupport {}

--- a/src/test/java/org/rhizome/server/domain/article/service/ArticleServiceImplTest.java
+++ b/src/test/java/org/rhizome/server/domain/article/service/ArticleServiceImplTest.java
@@ -1,0 +1,65 @@
+package org.rhizome.server.domain.article.service;
+
+import static org.assertj.core.api.BDDAssertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.rhizome.server.IntegrationTestSupport;
+import org.rhizome.server.domain.article.domain.Article;
+import org.rhizome.server.domain.article.domain.ArticleReference;
+import org.rhizome.server.domain.article.domain.ArticleReferenceRepository;
+import org.rhizome.server.domain.article.domain.ArticleRepository;
+import org.rhizome.server.domain.article.dto.response.AllArticleResponse;
+
+class ArticleServiceImplTest extends IntegrationTestSupport {
+    private final ArticleService articleService;
+    private final ArticleReferenceRepository articleReferenceRepository;
+    private final ArticleRepository articleRepository;
+
+    ArticleServiceImplTest(
+            ArticleService articleService,
+            ArticleReferenceRepository articleReferenceRepository,
+            ArticleRepository articleRepository) {
+        this.articleService = articleService;
+        this.articleReferenceRepository = articleReferenceRepository;
+        this.articleRepository = articleRepository;
+    }
+
+    @AfterEach
+    void tearDown() {
+        articleReferenceRepository.deleteAllInBatch();
+        articleRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 모든_게시글을_조회한다() {
+        // given
+        Article article1 = Article.builder().title("1번 게시글").build();
+        Article article2 = Article.builder().title("2번 게시글").build();
+        Article article3 = Article.builder().title("3번 게시글").build();
+        articleRepository.saveAll(List.of(article1, article2, article3));
+
+        ArticleReference reference = ArticleReference.builder()
+                .sourceArticle(article1)
+                .targetArticle(article2)
+                .build();
+        articleReferenceRepository.save(reference);
+        // when
+        AllArticleResponse articles = articleService.getArticles();
+        // then
+        then(articles.articles())
+                .hasSize(3)
+                .extracting(
+                        AllArticleResponse.ArticleResponse::title, AllArticleResponse.ArticleResponse::relateArticles)
+                .containsExactlyInAnyOrder(
+                        tuple(
+                                "1번 게시글",
+                                List.of(new AllArticleResponse.ReferenceArticleResponse(
+                                        article2.getId(), article2.getTitle()))),
+                        tuple("2번 게시글", List.of()),
+                        tuple("3번 게시글", List.of()));
+    }
+}


### PR DESCRIPTION
## 작업 개요
트랜잭션 처리를 통해 세션이 닫히는 문제를 해결하고, 전체 게시글 조회에 대한 테스트를 작성했습니다.

## 작업 사항
- 트랜잭션을 도입하여 전체 게시글 조회 시 세션이 유지되도록 수정
- 전체 게시글 조회에 대한 단위 테스트 추가