### PR TITLE
Refactor(#14): 게시글 관련 테스트 코드 추가 및 가독성을 위한 리팩토링 

### DIFF
--- a/src/main/java/org/rhizome/server/domain/article/controller/ArticleController.java
+++ b/src/main/java/org/rhizome/server/domain/article/controller/ArticleController.java
@@ -34,10 +34,10 @@ public class ArticleController {
         return ApiResponse.success();
     }
 
-    @PutMapping
-    public ApiResponse<?> updateArticle(@RequestBody UpdateArticleRequest request) {
+    @PutMapping("/{id}")
+    public ApiResponse<?> updateArticle(@PathVariable Long id, @RequestBody UpdateArticleRequest request) {
         articleService.updateArticle(
-                request.id(),
+                id,
                 request.title(),
                 request.content(),
                 request.relateArticleIds().articleIds());

--- a/src/main/java/org/rhizome/server/domain/article/domain/Article.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/Article.java
@@ -51,6 +51,6 @@ public class Article extends BaseTimeEntity {
     public void update(String title, String content, LocalDateTime publishedAt) {
         this.title = Objects.requireNonNullElse(title, this.title);
         this.content = Objects.requireNonNullElse(content, this.content);
-        this.publishedAt = publishedAt;
+        this.publishedAt = Objects.requireNonNull(publishedAt, "게시글 작성 시간은 null 일 수 없습니다.");
     }
 }

--- a/src/main/java/org/rhizome/server/domain/article/domain/ArticleReferences.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/ArticleReferences.java
@@ -1,0 +1,49 @@
+package org.rhizome.server.domain.article.domain;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import lombok.Getter;
+
+@Getter
+public class ArticleReferences {
+    private final List<ArticleReference> values;
+
+    public ArticleReferences(List<ArticleReference> values) {
+        this.values = List.copyOf(values);
+    }
+
+    public static ArticleReferences createReferencesFrom(Article source, List<Article> targets) {
+        List<ArticleReference> references = targets.stream()
+                .map(target -> ArticleReference.create(source, target))
+                .toList();
+        return new ArticleReferences(references);
+    }
+
+    public Set<Long> findIdsToAdd(List<Long> candidateTargetIds) {
+        Set<Long> currentTargetIds = extractTargetIds();
+        Set<Long> candidateTargetIdSet = new HashSet<>(candidateTargetIds);
+
+        return candidateTargetIdSet.stream()
+                .filter(candidateId -> !currentTargetIds.contains(candidateId))
+                .collect(Collectors.toSet());
+    }
+
+    public ArticleReferences filterNotIn(List<Long> targetIds) {
+        Set<Long> newIds = new HashSet<>(targetIds);
+
+        return new ArticleReferences(values.stream()
+                .filter(ref -> !newIds.contains(ref.getTargetArticle().getId()))
+                .toList());
+    }
+
+    public boolean hasReference() {
+        return !values.isEmpty();
+    }
+
+    private Set<Long> extractTargetIds() {
+        return values.stream().map(ref -> ref.getTargetArticle().getId()).collect(Collectors.toSet());
+    }
+}

--- a/src/main/java/org/rhizome/server/domain/article/domain/ArticleReferences.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/ArticleReferences.java
@@ -5,12 +5,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import lombok.Getter;
-
-@Getter
-public class ArticleReferences {
-    private final List<ArticleReference> values;
-
+public record ArticleReferences(List<ArticleReference> values) {
     public ArticleReferences(List<ArticleReference> values) {
         this.values = List.copyOf(values);
     }

--- a/src/main/java/org/rhizome/server/domain/article/dto/request/UpdateArticleRequest.java
+++ b/src/main/java/org/rhizome/server/domain/article/dto/request/UpdateArticleRequest.java
@@ -1,3 +1,3 @@
 package org.rhizome.server.domain.article.dto.request;
 
-public record UpdateArticleRequest(Long id, String title, String content, RelateArticleRequest relateArticleIds) {}
+public record UpdateArticleRequest(String title, String content, RelateArticleRequest relateArticleIds) {}

--- a/src/main/java/org/rhizome/server/domain/article/dto/response/AllArticleResponse.java
+++ b/src/main/java/org/rhizome/server/domain/article/dto/response/AllArticleResponse.java
@@ -3,9 +3,7 @@ package org.rhizome.server.domain.article.dto.response;
 import java.util.List;
 
 public record AllArticleResponse(List<ArticleResponse> articles) {
-
-    public record ArticleResponse(
-            Long id, String title, String content, List<ReferenceArticleResponse> relateArticles) {}
-
-    public record ReferenceArticleResponse(Long id, String title) {}
+    public static AllArticleResponse of(List<ArticleResponse> articles) {
+        return new AllArticleResponse(articles);
+    }
 }

--- a/src/main/java/org/rhizome/server/domain/article/dto/response/ArticleResponse.java
+++ b/src/main/java/org/rhizome/server/domain/article/dto/response/ArticleResponse.java
@@ -1,36 +1,25 @@
 package org.rhizome.server.domain.article.dto.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.rhizome.server.domain.article.domain.Article;
 
-import lombok.Builder;
-import lombok.Getter;
+public record ArticleResponse(
+        Long id,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        LocalDateTime publishedAt,
+        List<ReferenceArticleResponse> relateArticles) {
 
-@Getter
-public class ArticleResponse {
-    private Long id;
-    private String title;
-    private String content;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
-
-    @Builder
-    private ArticleResponse(Long id, String title, String content, LocalDateTime createdAt, LocalDateTime updatedAt) {
-        this.id = id;
-        this.title = title;
-        this.content = content;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
-    }
-
-    public static ArticleResponse of(Article article) {
-        return ArticleResponse.builder()
-                .id(article.getId())
-                .title(article.getTitle())
-                .content(article.getContent())
-                .createdAt(article.getCreatedAt())
-                .updatedAt(article.getUpdatedAt())
-                .build();
+    public static ArticleResponse of(Article article, List<ReferenceArticleResponse> relateArticles) {
+        return new ArticleResponse(
+                article.getId(),
+                article.getTitle(),
+                article.getContent(),
+                article.getCreatedAt(),
+                article.getPublishedAt(),
+                relateArticles);
     }
 }

--- a/src/main/java/org/rhizome/server/domain/article/dto/response/ReferenceArticleResponse.java
+++ b/src/main/java/org/rhizome/server/domain/article/dto/response/ReferenceArticleResponse.java
@@ -1,0 +1,9 @@
+package org.rhizome.server.domain.article.dto.response;
+
+import org.rhizome.server.domain.article.domain.Article;
+
+public record ReferenceArticleResponse(Long id, String title) {
+    public static ReferenceArticleResponse of(Article article) {
+        return new ReferenceArticleResponse(article.getId(), article.getTitle());
+    }
+}

--- a/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
+++ b/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
@@ -44,11 +44,10 @@ public class ArticleServiceImpl implements ArticleService {
     public void publishArticle(String title, String content, List<Long> relateArticleIds) {
         Article article = Article.create(title, content, localDateTimeHolder.now());
         Article savedArticle = articleRepository.save(article);
+
         List<Article> referenceArticles = articleRepository.findByIdIn(relateArticleIds);
-        List<ArticleReference> articleReferences = referenceArticles.stream()
-                .map(referenceArticle -> ArticleReference.create(savedArticle, referenceArticle))
-                .toList();
-        articleReferenceRepository.saveAll(articleReferences);
+        ArticleReferences articleReferences = ArticleReferences.createReferencesFrom(savedArticle, referenceArticles);
+        articleReferenceRepository.saveAll(articleReferences.values());
     }
 
     @Transactional

--- a/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
+++ b/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
@@ -63,7 +63,7 @@ public class ArticleServiceImpl implements ArticleService {
         ArticleReferences candidateRemoveReferences = existingReferences.filterNotIn(relateArticleIds);
 
         if (candidateRemoveReferences.hasReference()) {
-            articleReferenceRepository.deleteAllInBatch(candidateRemoveReferences.getValues());
+            articleReferenceRepository.deleteAllInBatch(candidateRemoveReferences.values());
         }
 
         Set<Long> idsToAdd = existingReferences.findIdsToAdd(relateArticleIds);
@@ -71,7 +71,7 @@ public class ArticleServiceImpl implements ArticleService {
         if (!idsToAdd.isEmpty()) {
             List<Article> candidateArticlesToAdd = articleRepository.findByIdIn(new ArrayList<>(idsToAdd));
             ArticleReferences newReferences = ArticleReferences.createReferencesFrom(article, candidateArticlesToAdd);
-            articleReferenceRepository.saveAll(newReferences.getValues());
+            articleReferenceRepository.saveAll(newReferences.values());
         }
     }
 

--- a/src/test/java/org/rhizome/server/domain/article/domain/ArticleReferencesTest.java
+++ b/src/test/java/org/rhizome/server/domain/article/domain/ArticleReferencesTest.java
@@ -1,0 +1,114 @@
+package org.rhizome.server.domain.article.domain;
+
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+import static org.assertj.core.api.BDDAssertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class ArticleReferencesTest {
+
+    @Test
+    @DisplayName("sourceArticle과 target과의 연결관계를 생성한다")
+    void sourceArticle과_target과의_연결관계를_생성한다() {
+        // given
+        Article sourceArticle =
+                Article.builder().title("source").content("source content").build();
+        Article targetArticle1 =
+                Article.builder().title("target1").content("target1 content").build();
+        Article targetArticle2 =
+                Article.builder().title("target2").content("target2 content").build();
+        // when
+        ArticleReferences references =
+                ArticleReferences.createReferencesFrom(sourceArticle, List.of(targetArticle1, targetArticle2));
+        // then
+        then(references.values())
+                .hasSize(2)
+                .extracting(ArticleReference::getSourceArticle, ArticleReference::getTargetArticle)
+                .containsExactlyInAnyOrder(tuple(sourceArticle, targetArticle1), tuple(sourceArticle, targetArticle2));
+    }
+
+    @Test
+    void findIdsToAdd_메서드는_현재_참조에_없는_새로운_ID들을_반환한다() {
+        // given
+        Article sourceArticle =
+                Article.builder().title("source").content("source content").build();
+        Article targetArticle1 =
+                Article.builder().title("target1").content("target1 content").build();
+        setArticleId(targetArticle1, 1L);
+        Article targetArticle2 =
+                Article.builder().title("target2").content("target2 content").build();
+        setArticleId(targetArticle2, 2L);
+
+        ArticleReferences references =
+                ArticleReferences.createReferencesFrom(sourceArticle, List.of(targetArticle1, targetArticle2));
+
+        // when
+        Set<Long> idsToAdd = references.findIdsToAdd(List.of(2L, 3L, 4L));
+
+        // then
+        then(idsToAdd).hasSize(2).containsExactlyInAnyOrder(3L, 4L);
+    }
+
+    @Test
+    void filterNotIn_메서드는_주어진_ID_목록에_없는_참조들만_필터링한다() {
+        // given
+        Article sourceArticle =
+                Article.builder().title("source").content("source content").build();
+        Article targetArticle1 =
+                Article.builder().title("target1").content("target1 content").build();
+        Article targetArticle2 =
+                Article.builder().title("target2").content("target2 content").build();
+        Article targetArticle3 =
+                Article.builder().title("target3").content("target3 content").build();
+
+        setArticleId(targetArticle1, 1L);
+        setArticleId(targetArticle2, 2L);
+        setArticleId(targetArticle3, 3L);
+
+        ArticleReferences references = ArticleReferences.createReferencesFrom(
+                sourceArticle, List.of(targetArticle1, targetArticle2, targetArticle3));
+
+        // when
+        ArticleReferences filteredReferences = references.filterNotIn(List.of(1L, 2L));
+
+        // then
+        then(filteredReferences.values())
+                .hasSize(1)
+                .extracting(ArticleReference::getTargetArticle)
+                .containsExactly(targetArticle3);
+    }
+
+    @Test
+    void hasReference_메서드는_참조가_있으면_true를_반환한다() {
+        // given
+        Article sourceArticle =
+                Article.builder().title("source").content("source content").build();
+        Article targetArticle =
+                Article.builder().title("target").content("target content").build();
+        ArticleReferences references = ArticleReferences.createReferencesFrom(sourceArticle, List.of(targetArticle));
+
+        // when
+        // then
+        then(references.hasReference()).isTrue();
+    }
+
+    @Test
+    void hasReference_메서드는_참조가_없으면_false를_반환한다() {
+        // given
+        ArticleReferences references = new ArticleReferences(List.of());
+
+        // when
+        // then
+        then(references.hasReference()).isFalse();
+    }
+
+    private void setArticleId(Article article, Long id) {
+        ReflectionTestUtils.setField(article, "id", id);
+    }
+}

--- a/src/test/java/org/rhizome/server/domain/article/domain/ArticleTest.java
+++ b/src/test/java/org/rhizome/server/domain/article/domain/ArticleTest.java
@@ -1,0 +1,63 @@
+package org.rhizome.server.domain.article.domain;
+
+import static org.assertj.core.api.BDDAssertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.assertj.core.api.BDDAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class ArticleTest {
+
+    @Nested
+    class update_메서드는 {
+        // given
+        Article article;
+
+        @BeforeEach
+        void setUp() {
+            article = Article.builder()
+                    .title("기존 제목")
+                    .content("기존 내용")
+                    .publishedAt(LocalDateTime.of(2025, 5, 19, 0, 0))
+                    .build();
+        }
+
+        @Test
+        void 모든_값이_들어오면_모두_수정된다() {
+            // given
+            LocalDateTime newTime = LocalDateTime.of(2025, 5, 20, 11, 0);
+            // when
+            article.update("새로운 제목", "새로운 내용", newTime);
+            // then
+            then(article)
+                    .extracting(Article::getTitle, Article::getContent, Article::getPublishedAt)
+                    .containsExactly("새로운 제목", "새로운 내용", newTime);
+        }
+
+        @Test
+        void 제목이_null이면_기존_제목을_유지한다() {
+            // when
+            article.update(null, "새로운 내용", LocalDateTime.now());
+            then(article).extracting(Article::getTitle, Article::getContent).containsExactly("기존 제목", "새로운 내용");
+        }
+
+        @Test
+        void 내용이_null이면_기존_내용을_유지한다() {
+            // when
+            article.update("새로운 제목", null, LocalDateTime.now());
+            // then
+            then(article).extracting(Article::getTitle, Article::getContent).containsExactly("새로운 제목", "기존 내용");
+        }
+
+        @Test
+        void 출판_시간은_null로_변경_할_수_없다() {
+            BDDAssertions.thenThrownBy(() -> article.update("새로운 제목", "새로운 내용", null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("게시글 작성 시간은 null 일 수 없습니다.");
+        }
+    }
+}

--- a/src/test/java/org/rhizome/server/domain/article/service/ArticleServiceImplTest.java
+++ b/src/test/java/org/rhizome/server/domain/article/service/ArticleServiceImplTest.java
@@ -1,7 +1,7 @@
 package org.rhizome.server.domain.article.service;
 
-import static org.assertj.core.api.BDDAssertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.tuple;
 
 import java.util.List;
 
@@ -32,6 +32,32 @@ class ArticleServiceImplTest extends IntegrationTestSupport {
     void tearDown() {
         articleReferenceRepository.deleteAllInBatch();
         articleRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 게시글을_작성한다() {
+        // given
+        // when
+        articleService.publishArticle("개발자의 삶", "개발자는 힘들다", List.of());
+        // then
+        then(articleRepository.findAll())
+                .hasSize(1)
+                .extracting(Article::getTitle, Article::getContent)
+                .containsExactlyInAnyOrder(tuple("개발자의 삶", "개발자는 힘들다"));
+    }
+
+    @Test
+    void 게시글을_수정한다() {
+        // given
+        Article article = Article.builder().title("개발자의 삶").content("개발자는 힘들다").build();
+        Article savedArticle = articleRepository.save(article);
+        // when
+        articleService.updateArticle(savedArticle.getId(), "통근의 삶", "왕복 한시간반은 어렵다..", List.of());
+        // then
+        then(articleRepository.findAll())
+                .hasSize(1)
+                .extracting(Article::getTitle, Article::getContent)
+                .containsExactlyInAnyOrder(tuple("통근의 삶", "왕복 한시간반은 어렵다.."));
     }
 
     @Test

--- a/src/test/java/org/rhizome/server/domain/article/service/ArticleServiceImplTest.java
+++ b/src/test/java/org/rhizome/server/domain/article/service/ArticleServiceImplTest.java
@@ -13,6 +13,8 @@ import org.rhizome.server.domain.article.domain.ArticleReference;
 import org.rhizome.server.domain.article.domain.ArticleReferenceRepository;
 import org.rhizome.server.domain.article.domain.ArticleRepository;
 import org.rhizome.server.domain.article.dto.response.AllArticleResponse;
+import org.rhizome.server.domain.article.dto.response.ArticleResponse;
+import org.rhizome.server.domain.article.dto.response.ReferenceArticleResponse;
 
 class ArticleServiceImplTest extends IntegrationTestSupport {
     private final ArticleService articleService;
@@ -78,13 +80,9 @@ class ArticleServiceImplTest extends IntegrationTestSupport {
         // then
         then(articles.articles())
                 .hasSize(3)
-                .extracting(
-                        AllArticleResponse.ArticleResponse::title, AllArticleResponse.ArticleResponse::relateArticles)
+                .extracting(ArticleResponse::title, ArticleResponse::relateArticles)
                 .containsExactlyInAnyOrder(
-                        tuple(
-                                "1번 게시글",
-                                List.of(new AllArticleResponse.ReferenceArticleResponse(
-                                        article2.getId(), article2.getTitle()))),
+                        tuple("1번 게시글", List.of(new ReferenceArticleResponse(article2.getId(), article2.getTitle()))),
                         tuple("2번 게시글", List.of()),
                         tuple("3번 게시글", List.of()));
     }


### PR DESCRIPTION
## 작업 개요
게시글 관리의 리팩토링 및 테스트 추가를 진행했습니다.

## 작업 사항
- 일급 컬렉션을 `record`로 변경 및 관련 메서드 테스트 추가
- 게시글 수정 로직을 일급 컬렉션을 활용해 리팩토링
- 단건 조회 시 연결 게시글 포함 로직 추가 및 응답 리팩토링
- 제출시간을 non-null로 변경 및 수정 작업 관련 테스트 추가
- 게시글 생성 및 수정에 대한 테스트 작성

## 고민한 점들
- 게시글과 관련된 데이터의 효율적인 구조화 및 관리 방법에 대해 고민해 보았습니다.
- `record`를 사용하며 설계의 간단함과 이해도를 높이는 방안을 생각했습니다.

## 추가해야 할 사항 (또는 더 고민해야 할 점)
- ~~단건 조회의 경우 테스트 코드가 존재하지 않습니다.~~
- Repository의 경우 테스트 코드가 없습니다 (해야된다고 생각하는지 고민해볼 것)
- ~~일급 컬렉션 더 맛있게 쓸 수 있을 것 같은데 이게 최선인지 생각해봐야 될 것 같습니다~~ 