### PR TITLE
Feat(#16): 게시글 삭제 및 소프트 삭제 기능 구현

### DIFF
--- a/src/main/java/org/rhizome/server/domain/article/controller/ArticleController.java
+++ b/src/main/java/org/rhizome/server/domain/article/controller/ArticleController.java
@@ -48,4 +48,10 @@ public class ArticleController {
     public ApiResponse<AllArticleResponse> getArticles() {
         return ApiResponse.success(articleService.getArticles());
     }
+
+    @DeleteMapping("/{id}")
+    public ApiResponse<?> deleteArticle(@PathVariable Long id) {
+        articleService.deleteArticle(id);
+        return ApiResponse.success();
+    }
 }

--- a/src/main/java/org/rhizome/server/domain/article/domain/ArticleReferenceRepository.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/ArticleReferenceRepository.java
@@ -5,7 +5,5 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArticleReferenceRepository extends JpaRepository<ArticleReference, Long> {
-    List<ArticleReference> findBySourceArticle(Article sourceArticle);
-
     List<ArticleReference> findBySourceArticleAndDeletedAtIsNull(Article sourceArticle);
 }

--- a/src/main/java/org/rhizome/server/domain/article/domain/ArticleReferenceRepository.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/ArticleReferenceRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArticleReferenceRepository extends JpaRepository<ArticleReference, Long> {
     List<ArticleReference> findBySourceArticle(Article sourceArticle);
+
+    List<ArticleReference> findBySourceArticleAndDeletedAtIsNull(Article sourceArticle);
 }

--- a/src/main/java/org/rhizome/server/domain/article/domain/ArticleReferences.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/ArticleReferences.java
@@ -34,6 +34,12 @@ public record ArticleReferences(List<ArticleReference> values) {
                 .toList());
     }
 
+    public void deleteAll() {
+        for (ArticleReference reference : values) {
+            reference.delete();
+        }
+    }
+
     public boolean hasReference() {
         return !values.isEmpty();
     }

--- a/src/main/java/org/rhizome/server/domain/article/domain/ArticleRepository.java
+++ b/src/main/java/org/rhizome/server/domain/article/domain/ArticleRepository.java
@@ -7,5 +7,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ArticleRepository extends JpaRepository<Article, Long> {
-    List<Article> findByIdIn(List<Long> ids);
+    List<Article> findByIdInAndDeletedAtIsNull(List<Long> ids);
+
+    List<Article> findByDeletedAtIsNull();
 }

--- a/src/main/java/org/rhizome/server/domain/article/service/ArticleService.java
+++ b/src/main/java/org/rhizome/server/domain/article/service/ArticleService.java
@@ -13,4 +13,6 @@ public interface ArticleService {
     void updateArticle(Long id, String title, String content, List<Long> relateArticleIds);
 
     AllArticleResponse getArticles();
+
+    void deleteArticle(Long id);
 }

--- a/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
+++ b/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
@@ -96,6 +96,7 @@ public class ArticleServiceImpl implements ArticleService {
         return new AllArticleResponse(articleResponses);
     }
 
+    @Override
     @Transactional
     public void deleteArticle(Long id) {
         Article article = findArticleBy(id);

--- a/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
+++ b/src/main/java/org/rhizome/server/domain/article/service/ArticleServiceImpl.java
@@ -94,6 +94,15 @@ public class ArticleServiceImpl implements ArticleService {
         return new AllArticleResponse(articleResponses);
     }
 
+    @Transactional
+    public void deleteArticle(Long id) {
+        Article article = findArticleBy(id);
+        ArticleReferences articleReferences =
+                new ArticleReferences(articleReferenceRepository.findBySourceArticle(article));
+        articleReferences.deleteAll();
+        article.delete();
+    }
+
     private Article findArticleBy(Long id) {
         return articleRepository.findById(id).orElseThrow(() -> new CoreException(ARTICLE_NOT_FOUND));
     }

--- a/src/main/java/org/rhizome/server/support/BaseTimeEntity.java
+++ b/src/main/java/org/rhizome/server/support/BaseTimeEntity.java
@@ -39,4 +39,8 @@ public class BaseTimeEntity {
         }
         return deletedAt.atZone(ZoneId.of("Asia/Seoul")).toLocalDateTime();
     }
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+    }
 }

--- a/src/test/java/org/rhizome/server/domain/article/domain/ArticleReferencesTest.java
+++ b/src/test/java/org/rhizome/server/domain/article/domain/ArticleReferencesTest.java
@@ -108,6 +108,28 @@ class ArticleReferencesTest {
         then(references.hasReference()).isFalse();
     }
 
+    @Test
+    void 연결관계를_삭제한다() {
+        // given
+        Article sourceArticle =
+                Article.builder().title("source").content("source content").build();
+        Article targetArticle1 =
+                Article.builder().title("target").content("target content").build();
+        Article targetArticle2 =
+                Article.builder().title("target").content("target content").build();
+        ArticleReference reference1 = ArticleReference.create(sourceArticle, targetArticle1);
+        ArticleReference reference2 = ArticleReference.create(sourceArticle, targetArticle2);
+
+        ArticleReferences references = new ArticleReferences(List.of(reference1, reference2));
+
+        // when
+        references.deleteAll();
+
+        // then
+        then(reference1.getDeletedAt()).isNotNull();
+        then(reference2.getDeletedAt()).isNotNull();
+    }
+
     private void setArticleId(Article article, Long id) {
         ReflectionTestUtils.setField(article, "id", id);
     }

--- a/src/test/java/org/rhizome/server/domain/article/service/ArticleServiceImplTest.java
+++ b/src/test/java/org/rhizome/server/domain/article/service/ArticleServiceImplTest.java
@@ -245,7 +245,7 @@ class ArticleServiceImplTest extends IntegrationTestSupport {
                 Article.builder().title("통근의 삶").content("왕복 한시간반은 어렵다..").build();
         Article referenceArticle2 = Article.builder()
                 .title("소프트딜리트하는 방법")
-                .content("deltedAt을 이용해 시간을 넣고 값이 있으면 삭제된 것으로 취급한다")
+                .content("deletedAt을 이용해 시간을 넣고 값이 있으면 삭제된 것으로 취급한다")
                 .build();
         articleRepository.saveAll(List.of(article, referenceArticle1, referenceArticle2));
         ArticleReference reference1 = ArticleReference.builder()

--- a/src/test/java/org/rhizome/server/domain/article/service/ArticleServiceImplTest.java
+++ b/src/test/java/org/rhizome/server/domain/article/service/ArticleServiceImplTest.java
@@ -163,6 +163,11 @@ class ArticleServiceImplTest extends IntegrationTestSupport {
                     Article.builder().title("통근의 삶").content("왕복 한시간반은 어렵다..").build();
             article3 = Article.builder().title("개발자의 삶").content("개발자는 힘들다").build();
             articleRepository.saveAll(List.of(article1, article2, article3));
+            ArticleReference reference = ArticleReference.builder()
+                    .sourceArticle(article1)
+                    .targetArticle(article2)
+                    .build();
+            articleReferenceRepository.save(reference);
             // when
             articleService.updateArticle(article1.getId(), "통근의 삶", "왕복 한시간반은 어렵다..", List.of());
             // then
@@ -172,7 +177,9 @@ class ArticleServiceImplTest extends IntegrationTestSupport {
                                     .orElseThrow(() -> new AssertionError("게시글을 찾을 수 없습니다.")))
                             .extracting(Article::getTitle, Article::getContent)
                             .containsExactly("통근의 삶", "왕복 한시간반은 어렵다.."),
-                    () -> then(articleReferenceRepository.findAll()).isEmpty());
+                    () -> then(articleReferenceRepository.findAll())
+                            .extracting(ArticleReference::getDeletedAt)
+                            .isNotNull());
         }
 
         @Transactional


### PR DESCRIPTION
## 작업 개요
게시글 삭제 및 소프트 삭제(Soft Delete) 기능을 구현했습니다.

## 작업 사항
- 소프트 삭제 로직 추가: 데이터베이스에서 완전히 삭제하지 않고 `deleted` 플래그를 설정하여 관리하도록 구현.
- 게시글 삭제 API 구현: 요청 시 해당 게시글을 소프트 삭제 처리.

## 추가 사항
- deletedAt에 index 추가 필요
- 지금은 편의상 ddl을 update를 쓰고있는데 추후에 ddl 따로 관리하고 사용해야 할 듯 (외래키 제거 및 index 추가)